### PR TITLE
Fix ReadyEventArgs error spam

### DIFF
--- a/KoalaBot/Logging/Logger.cs
+++ b/KoalaBot/Logging/Logger.cs
@@ -184,7 +184,7 @@ namespace KoalaBot.Logging
 		/// </summary>
 		/// <param name="exception">The exception</param>
 		/// <param name="prefix">Formatting of the exception message</param>
-		public void LogError(Exception exception, string prefix = "Exception Occured.")
+		public void LogError(Exception exception, string prefix = "Exception Occurred.")
 		{
 			//Log the message of the exception
 			LogError("{0} {1}", prefix, exception.Message);

--- a/KoalaBot/Starwatch/Entities/RestResponse.cs
+++ b/KoalaBot/Starwatch/Entities/RestResponse.cs
@@ -19,7 +19,7 @@ namespace KoalaBot.Starwatch.Entities
         public RestStatus Status { get; protected set; }
 
         /// <summary>
-        /// Was the request succesful?
+        /// Was the request successful?
         /// </summary>
         public bool Success => Status == RestStatus.OK || Status == RestStatus.Async;
         public bool IsAsync => Status == RestStatus.Async;

--- a/KoalaBot/Ticker/TickerManager.cs
+++ b/KoalaBot/Ticker/TickerManager.cs
@@ -55,7 +55,7 @@ namespace KoalaBot.Ticker
             try
             {
                 //Tick
-                //Logger.Log("Ticking Activity with {0}", ticker);
+                Logger.Log("Ticking Activity with {0}", ticker);
                 activity = await ticker.GetActivityAsync(this);
             }
             catch (Exception ex)

--- a/KoalaBot/Ticker/TickerStarwatch.cs
+++ b/KoalaBot/Ticker/TickerStarwatch.cs
@@ -11,6 +11,7 @@ namespace KoalaBot.Ticker
 	class TickerStarwatch : ITickable
 	{
         public StarwatchClient Client { get; }
+        private bool FirstCall = true;
 
         public TickerStarwatch(StarwatchClient client)
         {
@@ -19,6 +20,13 @@ namespace KoalaBot.Ticker
 
 		public async Task<DiscordActivity> GetActivityAsync(TickerManager manager)
         {
+            // First call is a bit too heavy for startup. Using this makes it wait just long enough to not cause event timeouts.
+            if (FirstCall)
+            {
+                FirstCall = false;
+                return null;
+            }
+
             try
             {
                 var stats = await Client.GetStatisticsAsync();


### PR DESCRIPTION
#2 Is fixed by ignoring the first call in TickerStarwatch. This is a bit _magical_ but testing shows it works unfortunately. I don't really have a good solution other than this.